### PR TITLE
Implement "View All Closed Boards" Functionality for Workspaces

### DIFF
--- a/src/hooks/use-categorize-workspaces.ts
+++ b/src/hooks/use-categorize-workspaces.ts
@@ -25,17 +25,22 @@ export const useCategorizeWorkspaces = (workspaces: WorkspaceResType['result'][]
     const guestWorkspaces: WorkspaceResType['result'][] = []
 
     workspaces.forEach((workspace) => {
+      // Filter out closed boards (_destroy === true) for each workspace
+      const activeBoards = (workspace.boards || []).filter((board) => !board._destroy)
+
       // Check if user is in members array
       const isMember = workspace.members.some((member) => member.user_id === profile._id)
 
       if (isMember) {
-        memberWorkspaces.push(workspace)
+        memberWorkspaces.push({ ...workspace, boards: activeBoards })
       } else {
         // Check if user is in guests array
-        const isGuest = workspace.guests.some((id) => id === profile._id)
+        const isGuest = workspace.guests.some((guest) =>
+          typeof guest === 'string' ? guest === profile._id : guest._id === profile._id
+        )
 
         if (isGuest) {
-          guestWorkspaces.push(workspace)
+          guestWorkspaces.push({ ...workspace, boards: activeBoards })
         }
       }
     })

--- a/src/pages/Boards/BoardDetails/components/BoardBar/BoardBar.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardBar/BoardBar.tsx
@@ -15,7 +15,7 @@ import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
 import BoardUserGroup from '~/pages/Boards/BoardDetails/components/BoardUserGroup'
 import InviteBoardMembers from '~/pages/Boards/BoardDetails/components/InviteBoardMembers'
 import { useUpdateBoardMutation } from '~/queries/boards'
-import { useJoinWorkspaceBoardMutation } from '~/queries/workspaces'
+import { useJoinWorkspaceBoardMutation, workspaceApi } from '~/queries/workspaces'
 import { BoardResType } from '~/schemas/board.schema'
 import { UserType } from '~/schemas/user.schema'
 import { updateActiveBoard } from '~/store/slices/board.slice'
@@ -114,10 +114,19 @@ export default function BoardBar({
     updateBoardMutation({
       id: newActiveBoard._id,
       body: { title: newActiveBoard.title }
-    })
+    }).then((res) => {
+      if (!res.error) {
+        dispatch(
+          workspaceApi.util.invalidateTags([
+            { type: 'Workspace', id: newActiveBoard.workspace_id },
+            { type: 'Workspace', id: 'LIST' }
+          ])
+        )
 
-    // Emit socket event to notify other users about the board title update
-    socket?.emit('CLIENT_USER_UPDATED_BOARD', newActiveBoard)
+        // Emit socket event to notify other users about the board title update
+        socket?.emit('CLIENT_USER_UPDATED_BOARD', newActiveBoard)
+      }
+    })
   }
 
   const joinWorkspaceBoard = async () => {

--- a/src/pages/Workspaces/pages/BoardsList/BoardsList.tsx
+++ b/src/pages/Workspaces/pages/BoardsList/BoardsList.tsx
@@ -1,9 +1,7 @@
 import CloseIcon from '@mui/icons-material/Close'
 import InfoIcon from '@mui/icons-material/Info'
-import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import { Link as MuiLink } from '@mui/material'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import Popover from '@mui/material/Popover'
@@ -18,13 +16,15 @@ import { useCategorizeWorkspaces } from '~/hooks/use-categorize-workspaces'
 import { useInfiniteScroll } from '~/hooks/use-infinite-scroll'
 import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
 import BoardGrid from '~/pages/Workspaces/pages/BoardsList/components/BoardGrid'
-import { useGetWorkspacesQuery } from '~/queries/workspaces'
+import ClosedBoards from '~/pages/Workspaces/pages/BoardsList/components/ClosedBoards'
+import { useGetWorkspacesQuery, workspaceApi } from '~/queries/workspaces'
 import { WorkspaceResType } from '~/schemas/workspace.schema'
 import { appendWorkspaces, clearWorkspaces, setWorkspaces } from '~/store/slices/workspace.slice'
 
 export default function BoardsList() {
   const dispatch = useAppDispatch()
   const { workspaces } = useAppSelector((state) => state.workspace)
+  const { socket } = useAppSelector((state) => state.app)
 
   const [anchorGuestWorkspaceInfoPopoverElement, setAnchorGuestWorkspaceInfoPopoverElement] =
     useState<HTMLElement | null>(null)
@@ -113,10 +113,47 @@ export default function BoardsList() {
 
   const { memberWorkspaces, guestWorkspaces } = useCategorizeWorkspaces(workspaces)
 
+  const allWorkspaces = useMemo(() => [...memberWorkspaces, ...guestWorkspaces], [memberWorkspaces, guestWorkspaces])
+
   const hasClosedBoards = useMemo(
     () => workspaces.some((workspace) => workspace.boards.some((board) => board._destroy)),
     [workspaces]
   )
+
+  // Realtime: listen to workspace updates and refresh list
+  useEffect(() => {
+    if (!socket) return
+
+    socket.emit('CLIENT_JOIN_WORKSPACES_INDEX')
+
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    const scheduleRefresh = () => {
+      if (timer) return
+      timer = setTimeout(() => {
+        dispatch(workspaceApi.util.invalidateTags([{ type: 'Workspace', id: 'LIST' }]))
+        timer = null
+      }, 200)
+    }
+
+    const onUpdateWorkspace = () => scheduleRefresh()
+
+    const onReconnect = () => {
+      socket.emit('CLIENT_JOIN_WORKSPACES_INDEX')
+      scheduleRefresh()
+    }
+
+    socket.on('SERVER_WORKSPACE_UPDATED', onUpdateWorkspace)
+    socket.on('reconnect', onReconnect)
+
+    return () => {
+      socket.emit('CLIENT_LEAVE_WORKSPACES_INDEX')
+      socket.off('SERVER_WORKSPACE_UPDATED', onUpdateWorkspace)
+      socket.off('reconnect', onReconnect)
+
+      if (timer) clearTimeout(timer)
+    }
+  }, [socket, dispatch])
 
   return (
     <Box>
@@ -259,32 +296,7 @@ export default function BoardsList() {
         )}
       </Box>
 
-      {!hasClosedBoards && workspaces.length > 0 && (
-        <Box sx={{ mt: 6, pl: 1 }}>
-          <Button
-            variant='outlined'
-            startIcon={<VisibilityOffIcon />}
-            sx={{
-              textTransform: 'none',
-              fontWeight: 600,
-              px: 3,
-              py: 1,
-              borderRadius: 2,
-              color: (theme) => (theme.palette.mode === 'dark' ? '#90caf9' : '#1976d2'),
-              borderColor: (theme) => (theme.palette.mode === 'dark' ? '#525252' : '#e0e0e0'),
-              bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'transparent' : '#fafafa'),
-              '&:hover': {
-                borderColor: (theme) => theme.palette.primary.main,
-                bgcolor: (theme) => (theme.palette.mode === 'dark' ? '#33485D' : '#e3f2fd'),
-                boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)'
-              }
-            }}
-            disabled
-          >
-            View all closed boards
-          </Button>
-        </Box>
-      )}
+      {hasClosedBoards && <ClosedBoards workspaces={allWorkspaces} />}
     </Box>
   )
 }

--- a/src/pages/Workspaces/pages/BoardsList/components/ClosedBoards/ClosedBoards.tsx
+++ b/src/pages/Workspaces/pages/BoardsList/components/ClosedBoards/ClosedBoards.tsx
@@ -1,0 +1,300 @@
+import ArchiveIcon from '@mui/icons-material/Archive'
+import CloseIcon from '@mui/icons-material/Close'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import CircularProgress from '@mui/material/CircularProgress'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import Divider from '@mui/material/Divider'
+import IconButton from '@mui/material/IconButton'
+import MenuItem from '@mui/material/MenuItem'
+import Select, { SelectChangeEvent } from '@mui/material/Select'
+import Skeleton from '@mui/material/Skeleton'
+import Stack from '@mui/material/Stack'
+import { alpha } from '@mui/material/styles'
+import Typography from '@mui/material/Typography'
+import { useEffect, useState } from 'react'
+import { DEFAULT_PAGINATION_LIMIT, DEFAULT_PAGINATION_PAGE } from '~/constants/pagination'
+import { useInfiniteScroll } from '~/hooks/use-infinite-scroll'
+import { useAppSelector } from '~/lib/redux/hooks'
+import ClosedBoardsListRow from '~/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow'
+import { useLazyGetBoardsQuery, useLeaveBoardMutation, useUpdateBoardMutation } from '~/queries/boards'
+import { BoardResType } from '~/schemas/board.schema'
+import { WorkspaceResType } from '~/schemas/workspace.schema'
+
+interface ClosedBoardsProps {
+  workspaces: WorkspaceResType['result'][]
+}
+
+export default function ClosedBoards({ workspaces }: ClosedBoardsProps) {
+  const [closedBoardsOpen, setClosedBoardsOpen] = useState(false)
+  const [pagination, setPagination] = useState({
+    page: DEFAULT_PAGINATION_PAGE,
+    total_page: 0
+  })
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+
+  const [triggerGetBoards, { data: boardsData, isFetching }] = useLazyGetBoardsQuery()
+
+  const [updateBoardMutation] = useUpdateBoardMutation()
+  const [leaveBoardMutation] = useLeaveBoardMutation()
+
+  const [allClosedBoards, setAllClosedBoards] = useState<BoardResType['result'][]>([])
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>('')
+
+  const { socket } = useAppSelector((state) => state.app)
+
+  useEffect(() => {
+    if (!closedBoardsOpen || !boardsData) return
+
+    const { boards, page, total_page } = boardsData.result
+    setPagination({ page, total_page })
+
+    if (page === DEFAULT_PAGINATION_PAGE) {
+      setAllClosedBoards(boards)
+    } else {
+      setAllClosedBoards((prev) => [...prev, ...boards])
+    }
+
+    setIsLoadingMore(false)
+  }, [boardsData, closedBoardsOpen])
+
+  const handleClosedBoardsOpen = () => {
+    setAllClosedBoards([])
+    setPagination({ page: DEFAULT_PAGINATION_PAGE, total_page: 0 })
+    setIsLoadingMore(false)
+    setSelectedWorkspaceId('')
+    setClosedBoardsOpen(true)
+
+    // Trigger initial fetch for page 1
+    triggerGetBoards({
+      page: DEFAULT_PAGINATION_PAGE,
+      limit: DEFAULT_PAGINATION_LIMIT,
+      state: 'closed'
+    })
+  }
+
+  const loadMoreBoards = () => {
+    if (pagination.page < pagination.total_page && !isFetching) {
+      setIsLoadingMore(true)
+      const nextPage = pagination.page + 1
+      triggerGetBoards({
+        page: nextPage,
+        limit: DEFAULT_PAGINATION_LIMIT,
+        state: 'closed',
+        ...(selectedWorkspaceId ? { workspace: selectedWorkspaceId } : {})
+      })
+    }
+  }
+
+  const { containerRef } = useInfiniteScroll({
+    onLoadMore: loadMoreBoards,
+    hasMore: pagination.page < pagination.total_page,
+    isLoading: isFetching || isLoadingMore,
+    threshold: 200
+  })
+
+  const boards = allClosedBoards
+
+  const handleClosedBoardsClose = () => {
+    setClosedBoardsOpen(false)
+  }
+
+  const handleWorkspaceChange = (event: SelectChangeEvent<string>) => {
+    const workspaceId = event.target.value as string
+
+    setSelectedWorkspaceId(workspaceId)
+    setAllClosedBoards([])
+    setPagination({ page: DEFAULT_PAGINATION_PAGE, total_page: 0 })
+    setIsLoadingMore(false)
+
+    triggerGetBoards({
+      page: DEFAULT_PAGINATION_PAGE,
+      limit: DEFAULT_PAGINATION_LIMIT,
+      state: 'closed',
+      ...(workspaceId ? { workspace: workspaceId } : {})
+    })
+  }
+
+  const onReopenBoard = (boardId: string, workspaceId: string) => {
+    updateBoardMutation({
+      id: boardId,
+      body: { _destroy: false }
+    }).then((res) => {
+      if (!res.error) {
+        if (boards.length === 1) {
+          handleClosedBoardsClose()
+        }
+
+        socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', workspaceId)
+      }
+    })
+  }
+
+  const onLeaveBoard = (boardId: string, workspaceId: string) => {
+    leaveBoardMutation(boardId).then((res) => {
+      if (!res.error) {
+        if (boards.length === 1) {
+          handleClosedBoardsClose()
+        }
+
+        socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', workspaceId, boardId)
+      }
+    })
+  }
+
+  return (
+    <Box sx={{ mt: 6, pl: 1 }}>
+      <Button
+        variant='outlined'
+        startIcon={<VisibilityOffIcon />}
+        onClick={handleClosedBoardsOpen}
+        sx={{
+          textTransform: 'none',
+          fontWeight: 600,
+          px: 3,
+          py: 1,
+          borderRadius: 2,
+          color: (theme) => (theme.palette.mode === 'dark' ? '#90caf9' : '#1976d2'),
+          borderColor: (theme) => (theme.palette.mode === 'dark' ? '#525252' : '#e0e0e0'),
+          bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'transparent' : '#fafafa'),
+          '&:hover': {
+            borderColor: (theme) => theme.palette.primary.main,
+            bgcolor: (theme) => (theme.palette.mode === 'dark' ? '#33485D' : '#e3f2fd'),
+            boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)'
+          }
+        }}
+      >
+        View all closed boards
+      </Button>
+
+      <Dialog keepMounted open={closedBoardsOpen} onClose={handleClosedBoardsClose} fullWidth maxWidth='md'>
+        <DialogTitle sx={{ p: 2.5 }}>
+          <Stack direction='row' alignItems='center' spacing={1.5}>
+            <Stack
+              direction='row'
+              alignItems='center'
+              useFlexGap
+              spacing={1.25}
+              sx={{ flexGrow: 1, minWidth: 0, flexWrap: 'wrap' }}
+            >
+              <ArchiveIcon color='primary' fontSize='large' />
+              <Typography variant='h6' noWrap sx={{ fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                Closed boards
+              </Typography>
+              <Select
+                size='small'
+                sx={{ minWidth: 160, flexShrink: 0 }}
+                value={selectedWorkspaceId}
+                onChange={handleWorkspaceChange}
+                displayEmpty
+              >
+                <MenuItem value=''>All boards</MenuItem>
+                {workspaces.map((workspace) => (
+                  <MenuItem key={workspace._id} value={workspace._id}>
+                    {workspace.title}
+                  </MenuItem>
+                ))}
+              </Select>
+            </Stack>
+            <IconButton onClick={handleClosedBoardsClose} aria-label='Close' sx={{ ml: 'auto', flexShrink: 0 }}>
+              <CloseIcon />
+            </IconButton>
+          </Stack>
+        </DialogTitle>
+
+        <DialogContent dividers sx={{ p: 0 }} ref={containerRef}>
+          <Box role='list' sx={{ overflowX: 'auto', WebkitOverflowScrolling: 'touch' }}>
+            {boards.length === 0 && isFetching && (
+              <Box>
+                {Array.from({ length: 3 }).map((_, idx) => (
+                  <Box key={idx}>
+                    <Stack
+                      direction='row'
+                      alignItems='center'
+                      justifyContent='space-between'
+                      sx={{ px: 2, py: 1.5, gap: 2, minWidth: 'max-content' }}
+                    >
+                      <Stack direction='row' alignItems='center' spacing={2} sx={{ minWidth: 0 }}>
+                        <Skeleton variant='rounded' width={44} height={44} sx={{ borderRadius: 1.25 }} />
+                        <Box sx={{ minWidth: 0, width: 240 }}>
+                          <Skeleton variant='text' width='80%' height={20} />
+                          <Skeleton variant='text' width='50%' height={16} />
+                        </Box>
+                      </Stack>
+
+                      <Stack direction='row' alignItems='center' spacing={1.25} flexShrink={0}>
+                        <Skeleton variant='rounded' width={72} height={32} />
+                        <Skeleton variant='rounded' width={96} height={32} />
+                      </Stack>
+                    </Stack>
+                    {idx < 2 && <Divider />}
+                  </Box>
+                ))}
+              </Box>
+            )}
+
+            {boards.length === 0 && !isFetching && (
+              <Box sx={{ px: 2, py: 2 }}>
+                <Box
+                  sx={{
+                    borderRadius: 2,
+                    px: 2,
+                    py: 4,
+                    mx: 1.5,
+                    textAlign: 'center',
+                    bgcolor: (theme) =>
+                      theme.palette.mode === 'dark'
+                        ? alpha(theme.palette.common.white, 0.06)
+                        : alpha(theme.palette.common.black, 0.04)
+                  }}
+                >
+                  <Stack alignItems='center' spacing={1.25}>
+                    <ArchiveIcon color='action' sx={{ fontSize: 36 }} />
+                    <Typography variant='subtitle1' sx={{ fontWeight: 600 }}>
+                      No boards have been closed
+                    </Typography>
+                    <Typography variant='body2' color='text.secondary' sx={{ maxWidth: 520 }}>
+                      Try selecting a different workspace or choose ‘All boards’. Closed boards will appear here when
+                      available.
+                    </Typography>
+                  </Stack>
+                </Box>
+              </Box>
+            )}
+
+            {boards.length > 0 &&
+              boards.map((board, index) => (
+                <ClosedBoardsListRow
+                  key={board._id}
+                  board={board}
+                  isLast={index === boards.length - 1}
+                  onReopenBoard={onReopenBoard}
+                  onLeaveBoard={onLeaveBoard}
+                />
+              ))}
+          </Box>
+
+          {isLoadingMore && (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+              <CircularProgress size={24} />
+            </Box>
+          )}
+        </DialogContent>
+
+        <DialogActions sx={{ p: 2 }}>
+          <Button
+            onClick={handleClosedBoardsClose}
+            variant='outlined'
+            sx={{ textTransform: 'none', fontWeight: 600, px: 2.5, borderRadius: 2 }}
+          >
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
+  )
+}

--- a/src/pages/Workspaces/pages/BoardsList/components/ClosedBoards/index.ts
+++ b/src/pages/Workspaces/pages/BoardsList/components/ClosedBoards/index.ts
@@ -1,0 +1,3 @@
+import ClosedBoards from '~/pages/Workspaces/pages/BoardsList/components/ClosedBoards/ClosedBoards'
+
+export default ClosedBoards

--- a/src/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/ClosedBoardsListRow.tsx
+++ b/src/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/ClosedBoardsListRow.tsx
@@ -1,0 +1,140 @@
+import { useBoardPermission } from '~/hooks/use-permissions'
+import { BoardResType } from '~/schemas/board.schema'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import Avatar from '@mui/material/Avatar'
+import MuiLink from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import Tooltip from '@mui/material/Tooltip'
+import Button from '@mui/material/Button'
+import Divider from '@mui/material/Divider'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import { alpha } from '@mui/material/styles'
+
+interface ClosedBoardsListRowProps {
+  board: BoardResType['result']
+  isLast: boolean
+  onReopenBoard: (boardId: string, workspaceId: string) => void
+  onLeaveBoard: (boardId: string, workspaceId: string) => void
+}
+
+export default function ClosedBoardsListRow({ board, isLast, onReopenBoard, onLeaveBoard }: ClosedBoardsListRowProps) {
+  const { isAdmin, isNormal, isObserver } = useBoardPermission(board)
+
+  return (
+    <Box role='listitem'>
+      <Stack
+        direction='row'
+        alignItems='center'
+        justifyContent='space-between'
+        sx={{
+          px: 2,
+          py: 1.5,
+          gap: 2.5,
+          minWidth: 'max-content',
+          '&:hover': {
+            bgcolor: (theme) =>
+              theme.palette.mode === 'dark'
+                ? alpha(theme.palette.common.white, 0.04)
+                : alpha(theme.palette.common.black, 0.03)
+          }
+        }}
+      >
+        <Stack direction='row' alignItems='center' spacing={2} sx={{ minWidth: 0 }}>
+          <Avatar
+            variant='rounded'
+            src={board.cover_photo}
+            alt={board.title}
+            sx={{
+              width: 44,
+              height: 44,
+              borderRadius: 1.25,
+              boxShadow: (theme) =>
+                theme.palette.mode === 'dark'
+                  ? '0 0 0 1px rgba(255,255,255,0.06) inset'
+                  : '0 0 0 1px rgba(0,0,0,0.06) inset'
+            }}
+          >
+            {board.title.charAt(0)}
+          </Avatar>
+
+          <Box sx={{ minWidth: 0 }}>
+            <MuiLink
+              href={`/boards/${board._id}`}
+              underline='hover'
+              color='inherit'
+              sx={{
+                fontWeight: 600,
+                display: 'block',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap'
+              }}
+            >
+              {board.title}
+            </MuiLink>
+            <Typography
+              variant='body2'
+              color='text.secondary'
+              sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            >
+              {board.workspace.title}
+            </Typography>
+            {(isNormal || isObserver) && (
+              <Typography
+                variant='body2'
+                color='text.secondary'
+                sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '12px' }}
+              >
+                You were not an admin on this board, so you cannot reopen it.
+              </Typography>
+            )}
+          </Box>
+        </Stack>
+
+        <Stack direction='row' alignItems='center' spacing={1.25} flexShrink={0}>
+          {isAdmin ? (
+            <>
+              <Tooltip title='Reopen this board'>
+                <span>
+                  <Button
+                    variant='contained'
+                    size='small'
+                    onClick={() => onReopenBoard(board._id, board.workspace_id)}
+                    sx={{ textTransform: 'none', fontWeight: 600, px: 2.25 }}
+                  >
+                    Reopen
+                  </Button>
+                </span>
+              </Tooltip>
+
+              <Button
+                variant='contained'
+                color='error'
+                size='small'
+                startIcon={<DeleteOutlineIcon />}
+                onClick={() => {}}
+                sx={{ textTransform: 'none', fontWeight: 600, px: 2.25 }}
+                disabled
+              >
+                Delete
+              </Button>
+            </>
+          ) : isNormal || isObserver ? (
+            <Button
+              variant='contained'
+              color='error'
+              size='small'
+              startIcon={<DeleteOutlineIcon />}
+              onClick={() => onLeaveBoard(board._id, board.workspace_id)}
+              sx={{ textTransform: 'none', fontWeight: 600, px: 2.25 }}
+            >
+              Leave
+            </Button>
+          ) : null}
+        </Stack>
+      </Stack>
+      {!isLast && <Divider />}
+    </Box>
+  )
+}

--- a/src/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/index.ts
+++ b/src/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/index.ts
@@ -1,0 +1,3 @@
+import ClosedBoardsListRow from '~/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/ClosedBoardsListRow'
+
+export default ClosedBoardsListRow

--- a/src/queries/boards.ts
+++ b/src/queries/boards.ts
@@ -22,7 +22,12 @@ export const boardApi = createApi({
           const { data } = await queryFulfilled
           const board = data.result
 
-          dispatch(workspaceApi.util.invalidateTags([{ type: 'Workspace', id: board?.workspace_id }]))
+          dispatch(
+            workspaceApi.util.invalidateTags([
+              { type: 'Workspace', id: board?.workspace_id },
+              { type: 'Workspace', id: 'LIST' }
+            ])
+          )
         } catch (error) {
           toast.error('There was an error creating the board')
           console.error(error)
@@ -71,6 +76,14 @@ export const boardApi = createApi({
 
     leaveBoard: build.mutation<BoardResType, string>({
       query: (id) => ({ url: `${BOARD_API_URL}/${id}/members/me/leave`, method: 'POST' }),
+      async onQueryStarted(_args, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled
+          dispatch(workspaceApi.util.invalidateTags([{ type: 'Workspace', id: 'LIST' }]))
+        } catch (error) {
+          console.error(error)
+        }
+      },
       invalidatesTags: (_result, _error, id) => [
         { type: 'Board', id },
         { type: 'Board', id: 'LIST' }
@@ -82,6 +95,7 @@ export const boardApi = createApi({
 export const {
   useAddBoardMutation,
   useGetBoardsQuery,
+  useLazyGetBoardsQuery,
   useUpdateBoardMutation,
   useLeaveBoardMutation,
   useGetJoinedWorkspaceBoardsQuery

--- a/src/queries/workspaces.ts
+++ b/src/queries/workspaces.ts
@@ -150,7 +150,10 @@ export const workspaceApi = createApi({
           console.error(error)
         }
       },
-      invalidatesTags: (_result, _error, { workspace_id }) => [{ type: 'Workspace', id: workspace_id }]
+      invalidatesTags: (_result, _error, { workspace_id }) => [
+        { type: 'Workspace', workspace_id },
+        { type: 'Workspace', id: 'LIST' }
+      ]
     })
   })
 })

--- a/src/types/query-params.type.ts
+++ b/src/types/query-params.type.ts
@@ -32,5 +32,6 @@ export interface BoardInvitationQueryParams {
 
 export interface BoardQueryParams extends CommonQueryParams {
   keyword?: string
-  workspace_id?: string
+  state?: 'closed' | 'active'
+  workspace?: string
 }


### PR DESCRIPTION
This pull request introduces the ability to view all closed boards within workspaces, along with related UI and API enhancements.

- Adds a "View all closed boards" button to the Boards List page, opening a dialog to browse closed boards by workspace.
- Implements new components:
  - `ClosedBoards` dialog for listing closed boards.
  - `ClosedBoardsListRow` for rendering each closed board with actions (reopen, leave).
- Updates board and workspace queries to support filtering by board state (`active`/`closed`).
- Refines workspace categorization to exclude closed boards from active lists.
- Enhances cache invalidation logic for board/workspace mutations to ensure UI stays in sync.
- UI/UX improvements for closed boards dialog, including loading states and empty state messaging.
- Type updates to support new query parameters for board state and workspace filtering.

**Notes:**
- Only board admins can reopen closed boards; non-admins can leave closed boards.
- This feature improves board lifecycle management and user control over archived content.