### PR TITLE
Add Delete Board Functionality with Confirmation Popover

### DIFF
--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -23,7 +23,8 @@ export enum BoardPermission {
   EditCard = 'BOARD__EDIT_CARD',
   DeleteCard = 'BOARD__DELETE_CARD',
   Comment = 'BOARD__COMMENT',
-  Attach = 'BOARD__ATTACH'
+  Attach = 'BOARD__ATTACH',
+  DeleteBoard = 'BOARD__DELETE'
 }
 
 export const WORKSPACE_ROLE_PERMISSIONS: Record<WorkspaceMemberRoleType, WorkspacePermission[]> = {
@@ -55,7 +56,8 @@ export const BOARD_ROLE_PERMISSIONS: Record<BoardMemberRoleType, BoardPermission
     BoardPermission.EditCard,
     BoardPermission.DeleteCard,
     BoardPermission.Comment,
-    BoardPermission.Attach
+    BoardPermission.Attach,
+    BoardPermission.DeleteBoard
   ],
   [BoardRole.Member]: [
     BoardPermission.ViewBoard,

--- a/src/hooks/use-permissions.ts
+++ b/src/hooks/use-permissions.ts
@@ -116,7 +116,6 @@ interface UseBoardPermissionReturn {
   canDeleteCard: boolean
   canComment: boolean
   canAttach: boolean
-  // Alias derived capability; deleting a board is considered part of managing it
   canDeleteBoard: boolean
 }
 
@@ -189,6 +188,6 @@ export const useBoardPermission = (board?: BoardItem, userIdOverride?: string): 
     canDeleteCard: hasPermission(BoardPermission.DeleteCard) && !isClosed,
     canComment: hasPermission(BoardPermission.Comment) && !isClosed,
     canAttach: hasPermission(BoardPermission.Attach) && !isClosed,
-    canDeleteBoard: hasPermission(BoardPermission.ManageBoard) && !isClosed
+    canDeleteBoard: hasPermission(BoardPermission.DeleteBoard) && isClosed
   }
 }

--- a/src/pages/Boards/BoardDetails/BoardDetails.tsx
+++ b/src/pages/Boards/BoardDetails/BoardDetails.tsx
@@ -49,8 +49,17 @@ export default function BoardDetails() {
   const [updateColumnMutation] = useUpdateColumnMutation()
   const [moveCardToDifferentColumnMutation] = useMoveCardToDifferentColumnMutation()
 
-  const { isAdmin, isMember, isClosed, canManageBoard, canCreateColumn, canEditColumn, canCreateCard, canEditCard } =
-    useBoardPermission(activeBoard)
+  const {
+    isAdmin,
+    isMember,
+    isClosed,
+    canManageBoard,
+    canCreateColumn,
+    canEditColumn,
+    canCreateCard,
+    canEditCard,
+    canDeleteBoard
+  } = useBoardPermission(activeBoard)
 
   useEffect(() => {
     if (boardId) {
@@ -138,9 +147,14 @@ export default function BoardDetails() {
       )
     }
 
+    const onUserDeletedBoard = () => {
+      dispatch(clearActiveBoard())
+    }
+
     socket?.on('SERVER_BOARD_UPDATED', onUpdateBoard)
     socket?.on('SERVER_CARD_UPDATED', onUpdateCard)
     socket?.on('SERVER_USER_ACCEPTED_BOARD_INVITATION', onUserAcceptedBoardInvitation)
+    socket?.on('SERVER_USER_DELETED_BOARD', onUserDeletedBoard)
     socket?.on('connect', onConnect)
     socket?.on('disconnect', onDisconnect)
 
@@ -148,6 +162,7 @@ export default function BoardDetails() {
       socket?.off('SERVER_BOARD_UPDATED', onUpdateBoard)
       socket?.off('SERVER_CARD_UPDATED', onUpdateCard)
       socket?.off('SERVER_USER_ACCEPTED_BOARD_INVITATION', onUserAcceptedBoardInvitation)
+      socket?.off('SERVER_USER_DELETED_BOARD', onUserDeletedBoard)
       socket?.off('connect', onConnect)
       socket?.off('disconnect', onDisconnect)
     }
@@ -386,6 +401,7 @@ export default function BoardDetails() {
             boardId={boardId!}
             isBoardAdmin={isAdmin}
             canManageBoard={canManageBoard}
+            canDeleteBoard={canDeleteBoard}
           />
         </Box>
       </Box>

--- a/src/pages/Boards/BoardDetails/components/BoardDrawer/BoardDrawer.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardDrawer/BoardDrawer.tsx
@@ -21,6 +21,7 @@ import { BoardRole } from '~/constants/type'
 import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
 import ChangeBoardBackground from '~/pages/Boards/BoardDetails/components/BoardDrawer/ChangeBoardBackground'
 import CloseBoard from '~/pages/Boards/BoardDetails/components/BoardDrawer/CloseBoard'
+import DeleteBoard from '~/pages/Boards/BoardDetails/components/BoardDrawer/DeleteBoard'
 import { useLeaveBoardMutation, useUpdateBoardMutation } from '~/queries/boards'
 import { BoardMemberType } from '~/schemas/board.schema'
 import { clearActiveBoard, updateActiveBoard } from '~/store/slices/board.slice'
@@ -32,6 +33,7 @@ interface BoardDrawerProps {
   boardId: string
   isBoardAdmin: boolean
   canManageBoard: boolean
+  canDeleteBoard: boolean
 }
 
 export default function BoardDrawer({
@@ -40,7 +42,8 @@ export default function BoardDrawer({
   boardMembers,
   canManageBoard,
   isBoardAdmin,
-  boardId
+  boardId,
+  canDeleteBoard
 }: BoardDrawerProps) {
   const theme = useTheme()
 
@@ -65,6 +68,7 @@ export default function BoardDrawer({
   // Check if current user is the last admin
   const isLastAdmin = isCurrentUserAdmin && totalAdmins === 1
   const canLeaveBoard = currentUserMember && !isLastAdmin
+  const canReopenBoard = isBoardClosed && isBoardAdmin
 
   const leaveBoard = () => {
     leaveBoardMutation(boardId).then((res) => {
@@ -174,7 +178,7 @@ export default function BoardDrawer({
 
         {canManageBoard && <CloseBoard />}
 
-        {isBoardClosed && isBoardAdmin && (
+        {canReopenBoard && (
           <ListItem disablePadding>
             <ListItemButton onClick={reopenBoard}>
               <ListItemIcon>
@@ -195,6 +199,8 @@ export default function BoardDrawer({
             </ListItemButton>
           </ListItem>
         )}
+
+        {canDeleteBoard && <DeleteBoard boardId={boardId} />}
       </List>
     </Drawer>
   )

--- a/src/pages/Boards/BoardDetails/components/BoardDrawer/DeleteBoard/DeleteBoard.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardDrawer/DeleteBoard/DeleteBoard.tsx
@@ -1,0 +1,117 @@
+import CloseIcon from '@mui/icons-material/Close'
+import DeleteIcon from '@mui/icons-material/Delete'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import ListItem from '@mui/material/ListItem'
+import ListItemButton from '@mui/material/ListItemButton'
+import ListItemIcon from '@mui/material/ListItemIcon'
+import ListItemText from '@mui/material/ListItemText'
+import Popover from '@mui/material/Popover'
+import Typography from '@mui/material/Typography'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import path from '~/constants/path'
+import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
+import { useDeleteBoardMutation } from '~/queries/boards'
+import { workspaceApi } from '~/queries/workspaces'
+import { clearActiveBoard } from '~/store/slices/board.slice'
+
+interface DeleteBoardProps {
+  boardId: string
+}
+
+export default function DeleteBoard({ boardId }: DeleteBoardProps) {
+  const navigate = useNavigate()
+
+  const [anchorDeleteBoardPopoverElement, setAnchorDeleteBoardPopoverElement] = useState<HTMLElement | null>(null)
+
+  const isDeleteBoardPopoverOpen = Boolean(anchorDeleteBoardPopoverElement)
+
+  const deleteBoardPopoverId = isDeleteBoardPopoverOpen ? 'delete-board-popover' : undefined
+
+  const toggleDeleteBoardPopover = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    if (isDeleteBoardPopoverOpen) {
+      setAnchorDeleteBoardPopoverElement(null)
+    } else {
+      setAnchorDeleteBoardPopoverElement(event.currentTarget)
+    }
+  }
+
+  const handleDeleteBoardPopoverClose = () => {
+    setAnchorDeleteBoardPopoverElement(null)
+  }
+
+  const dispatch = useAppDispatch()
+
+  const { activeBoard } = useAppSelector((state) => state.board)
+  const { socket } = useAppSelector((state) => state.app)
+
+  const [deleteBoardMutation] = useDeleteBoardMutation()
+
+  const deleteBoard = () => {
+    deleteBoardMutation(boardId).then((res) => {
+      if (!res.error) {
+        const workspaceId = activeBoard?.workspace_id as string
+
+        dispatch(
+          workspaceApi.util.invalidateTags([
+            { type: 'Workspace', id: workspaceId },
+            { type: 'Workspace', id: 'LIST' }
+          ])
+        )
+
+        socket?.emit('CLIENT_USER_DELETED_BOARD', boardId)
+        socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', workspaceId)
+
+        navigate(path.workspaceHome.replace(':workspaceId', workspaceId))
+
+        dispatch(clearActiveBoard())
+      }
+    })
+  }
+
+  return (
+    <>
+      <ListItem disablePadding>
+        <ListItemButton onClick={toggleDeleteBoardPopover}>
+          <ListItemIcon>
+            <DeleteIcon color='error' />
+          </ListItemIcon>
+          <ListItemText secondary='Permanently delete board' />
+        </ListItemButton>
+      </ListItem>
+
+      <Popover
+        id={deleteBoardPopoverId}
+        open={isDeleteBoardPopoverOpen}
+        anchorEl={anchorDeleteBoardPopoverElement}
+        onClose={handleDeleteBoardPopoverClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        slotProps={{
+          paper: { sx: { width: 320, borderRadius: 2 } }
+        }}
+      >
+        <Box sx={{ p: 1.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2, position: 'relative' }}>
+            <Typography variant='subtitle1' sx={{ fontWeight: 'medium' }}>
+              Delete board?
+            </Typography>
+            <IconButton size='small' onClick={handleDeleteBoardPopoverClose} sx={{ position: 'absolute', right: 0 }}>
+              <CloseIcon fontSize='small' />
+            </IconButton>
+          </Box>
+
+          <Typography variant='body2' sx={{ mb: 3, color: 'text.secondary' }}>
+            All columns, cards and actions will be deleted, and you won’t be able to re-open the board. There is no
+            undo.
+          </Typography>
+
+          <Button variant='contained' color='error' fullWidth onClick={deleteBoard}>
+            Delete
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  )
+}

--- a/src/pages/Boards/BoardDetails/components/BoardDrawer/DeleteBoard/index.ts
+++ b/src/pages/Boards/BoardDetails/components/BoardDrawer/DeleteBoard/index.ts
@@ -1,0 +1,3 @@
+import DeleteBoard from '~/pages/Boards/BoardDetails/components/BoardDrawer/DeleteBoard/DeleteBoard'
+
+export default DeleteBoard

--- a/src/pages/Workspaces/components/WorkspaceClosedBoardsListRow/WorkspaceClosedBoardsListRow.tsx
+++ b/src/pages/Workspaces/components/WorkspaceClosedBoardsListRow/WorkspaceClosedBoardsListRow.tsx
@@ -1,29 +1,53 @@
-import { useBoardPermission } from '~/hooks/use-permissions'
-import { BoardResType } from '~/schemas/board.schema'
-import Box from '@mui/material/Box'
-import Stack from '@mui/material/Stack'
+import CloseIcon from '@mui/icons-material/Close'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import Avatar from '@mui/material/Avatar'
-import Typography from '@mui/material/Typography'
-import Tooltip from '@mui/material/Tooltip'
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
-import { alpha } from '@mui/material/styles'
+import IconButton from '@mui/material/IconButton'
 import MuiLink from '@mui/material/Link'
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import Popover from '@mui/material/Popover'
+import Stack from '@mui/material/Stack'
+import { alpha } from '@mui/material/styles'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { useState } from 'react'
+import { useBoardPermission } from '~/hooks/use-permissions'
+import { BoardResType } from '~/schemas/board.schema'
 
 interface WorkspaceClosedBoardsListRowProps {
   board: BoardResType['result']
   isLast: boolean
   onReopenBoard: (boardId: string) => void
   onLeaveBoard: (boardId: string) => void
+  onDeleteBoard: (boardId: string) => void
 }
 
 export default function WorkspaceClosedBoardsListRow({
   board,
   isLast,
   onReopenBoard,
-  onLeaveBoard
+  onLeaveBoard,
+  onDeleteBoard
 }: WorkspaceClosedBoardsListRowProps) {
+  const [anchorDeleteBoardPopoverElement, setAnchorDeleteBoardPopoverElement] = useState<HTMLElement | null>(null)
+
+  const isDeleteBoardPopoverOpen = Boolean(anchorDeleteBoardPopoverElement)
+
+  const deleteBoardPopoverId = isDeleteBoardPopoverOpen ? 'delete-board-popover' : undefined
+
+  const toggleDeleteBoardPopover = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    if (isDeleteBoardPopoverOpen) {
+      setAnchorDeleteBoardPopoverElement(null)
+    } else {
+      setAnchorDeleteBoardPopoverElement(event.currentTarget)
+    }
+  }
+
+  const handleDeleteBoardPopoverClose = () => {
+    setAnchorDeleteBoardPopoverElement(null)
+  }
+
   const { isAdmin, isNormal, isObserver } = useBoardPermission(board)
 
   return (
@@ -113,17 +137,61 @@ export default function WorkspaceClosedBoardsListRow({
                 </span>
               </Tooltip>
 
-              <Button
-                variant='contained'
-                color='error'
-                size='small'
-                startIcon={<DeleteOutlineIcon />}
-                onClick={() => {}}
-                sx={{ textTransform: 'none', fontWeight: 600, px: 2.25 }}
-                disabled
-              >
-                Delete
-              </Button>
+              <>
+                <Button
+                  variant='contained'
+                  color='error'
+                  size='small'
+                  startIcon={<DeleteOutlineIcon />}
+                  onClick={toggleDeleteBoardPopover}
+                  sx={{ textTransform: 'none', fontWeight: 600, px: 2.25 }}
+                >
+                  Delete
+                </Button>
+
+                <Popover
+                  id={deleteBoardPopoverId}
+                  open={isDeleteBoardPopoverOpen}
+                  anchorEl={anchorDeleteBoardPopoverElement}
+                  onClose={handleDeleteBoardPopoverClose}
+                  anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                  slotProps={{
+                    paper: { sx: { width: 320, borderRadius: 2 } }
+                  }}
+                >
+                  <Box sx={{ p: 1.5 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        mb: 2,
+                        position: 'relative'
+                      }}
+                    >
+                      <Typography variant='subtitle1' sx={{ fontWeight: 'medium' }}>
+                        Delete board?
+                      </Typography>
+                      <IconButton
+                        size='small'
+                        onClick={handleDeleteBoardPopoverClose}
+                        sx={{ position: 'absolute', right: 0 }}
+                      >
+                        <CloseIcon fontSize='small' />
+                      </IconButton>
+                    </Box>
+
+                    <Typography variant='body2' sx={{ mb: 3, color: 'text.secondary' }}>
+                      All columns, cards and actions will be deleted, and you won’t be able to re-open the board. There
+                      is no undo.
+                    </Typography>
+
+                    <Button variant='contained' color='error' fullWidth onClick={() => onDeleteBoard(board._id)}>
+                      Delete
+                    </Button>
+                  </Box>
+                </Popover>
+              </>
             </>
           ) : isNormal || isObserver ? (
             <Button

--- a/src/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/ClosedBoardsListRow.tsx
+++ b/src/pages/Workspaces/pages/BoardsList/components/ClosedBoardsListRow/ClosedBoardsListRow.tsx
@@ -1,24 +1,53 @@
-import { useBoardPermission } from '~/hooks/use-permissions'
-import { BoardResType } from '~/schemas/board.schema'
-import Box from '@mui/material/Box'
-import Stack from '@mui/material/Stack'
+import CloseIcon from '@mui/icons-material/Close'
+import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import Avatar from '@mui/material/Avatar'
-import MuiLink from '@mui/material/Link'
-import Typography from '@mui/material/Typography'
-import Tooltip from '@mui/material/Tooltip'
+import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
-import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
+import IconButton from '@mui/material/IconButton'
+import MuiLink from '@mui/material/Link'
+import Popover from '@mui/material/Popover'
+import Stack from '@mui/material/Stack'
 import { alpha } from '@mui/material/styles'
+import Tooltip from '@mui/material/Tooltip'
+import Typography from '@mui/material/Typography'
+import { useState } from 'react'
+import { useBoardPermission } from '~/hooks/use-permissions'
+import { BoardResType } from '~/schemas/board.schema'
 
 interface ClosedBoardsListRowProps {
   board: BoardResType['result']
   isLast: boolean
   onReopenBoard: (boardId: string, workspaceId: string) => void
   onLeaveBoard: (boardId: string, workspaceId: string) => void
+  onDeleteBoard: (boardId: string, workspaceId: string) => void
 }
 
-export default function ClosedBoardsListRow({ board, isLast, onReopenBoard, onLeaveBoard }: ClosedBoardsListRowProps) {
+export default function ClosedBoardsListRow({
+  board,
+  isLast,
+  onReopenBoard,
+  onLeaveBoard,
+  onDeleteBoard
+}: ClosedBoardsListRowProps) {
+  const [anchorDeleteBoardPopoverElement, setAnchorDeleteBoardPopoverElement] = useState<HTMLElement | null>(null)
+
+  const isDeleteBoardPopoverOpen = Boolean(anchorDeleteBoardPopoverElement)
+
+  const deleteBoardPopoverId = isDeleteBoardPopoverOpen ? 'delete-board-popover' : undefined
+
+  const toggleDeleteBoardPopover = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    if (isDeleteBoardPopoverOpen) {
+      setAnchorDeleteBoardPopoverElement(null)
+    } else {
+      setAnchorDeleteBoardPopoverElement(event.currentTarget)
+    }
+  }
+
+  const handleDeleteBoardPopoverClose = () => {
+    setAnchorDeleteBoardPopoverElement(null)
+  }
+
   const { isAdmin, isNormal, isObserver } = useBoardPermission(board)
 
   return (
@@ -113,12 +142,59 @@ export default function ClosedBoardsListRow({ board, isLast, onReopenBoard, onLe
                 color='error'
                 size='small'
                 startIcon={<DeleteOutlineIcon />}
-                onClick={() => {}}
+                onClick={toggleDeleteBoardPopover}
                 sx={{ textTransform: 'none', fontWeight: 600, px: 2.25 }}
-                disabled
               >
                 Delete
               </Button>
+
+              <Popover
+                id={deleteBoardPopoverId}
+                open={isDeleteBoardPopoverOpen}
+                anchorEl={anchorDeleteBoardPopoverElement}
+                onClose={handleDeleteBoardPopoverClose}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                slotProps={{
+                  paper: { sx: { width: 320, borderRadius: 2 } }
+                }}
+              >
+                <Box sx={{ p: 1.5 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      mb: 2,
+                      position: 'relative'
+                    }}
+                  >
+                    <Typography variant='subtitle1' sx={{ fontWeight: 'medium' }}>
+                      Delete board?
+                    </Typography>
+                    <IconButton
+                      size='small'
+                      onClick={handleDeleteBoardPopoverClose}
+                      sx={{ position: 'absolute', right: 0 }}
+                    >
+                      <CloseIcon fontSize='small' />
+                    </IconButton>
+                  </Box>
+
+                  <Typography variant='body2' sx={{ mb: 3, color: 'text.secondary' }}>
+                    All columns, cards and actions will be deleted, and you won’t be able to re-open the board. There is
+                    no undo.
+                  </Typography>
+
+                  <Button
+                    variant='contained'
+                    color='error'
+                    fullWidth
+                    onClick={() => onDeleteBoard(board._id, board.workspace_id)}
+                  >
+                    Delete
+                  </Button>
+                </Box>
+              </Popover>
             </>
           ) : isNormal || isObserver ? (
             <Button

--- a/src/pages/Workspaces/pages/Home/Home.tsx
+++ b/src/pages/Workspaces/pages/Home/Home.tsx
@@ -36,7 +36,7 @@ export default function Home() {
       </Helmet>
 
       <List
-        sx={{ mx: { xs: 1, md: 0 }, width: '100%', maxWidth: 500 }}
+        sx={{ mx: { xs: 1, md: 0 }, width: '100%', maxWidth: { xs: '100%', sm: 500 } }}
         aria-labelledby='nested-list-subheader'
         subheader={
           <ListSubheader

--- a/src/pages/Workspaces/pages/WorkspaceBoards/WorkspaceBoards.tsx
+++ b/src/pages/Workspaces/pages/WorkspaceBoards/WorkspaceBoards.tsx
@@ -192,9 +192,8 @@ export default function WorkspaceBoards() {
               {filteredBoards.length > 0 && filteredBoards.map((board) => <BoardCard key={board._id} board={board} />)}
             </>
           )}
-
-          {hasClosedBoards && <WorkspaceClosedBoards workspaceId={workspaceId!} />}
         </Grid>
+        {hasClosedBoards && <WorkspaceClosedBoards workspaceId={workspaceId!} />}
       </Box>
 
       <NewBoardDialog

--- a/src/queries/boards.ts
+++ b/src/queries/boards.ts
@@ -2,7 +2,13 @@ import { createApi } from '@reduxjs/toolkit/query/react'
 import { toast } from 'react-toastify'
 import axiosBaseQuery from '~/lib/redux/helpers'
 import { workspaceApi } from '~/queries/workspaces'
-import { BoardListResType, BoardResType, CreateBoardBodyType, UpdateBoardBodyType } from '~/schemas/board.schema'
+import {
+  BoardListResType,
+  BoardResType,
+  CreateBoardBodyType,
+  DeleteBoardResType,
+  UpdateBoardBodyType
+} from '~/schemas/board.schema'
 import { BoardQueryParams, CommonQueryParams } from '~/types/query-params.type'
 
 const BOARD_API_URL = '/boards' as const
@@ -96,6 +102,18 @@ export const boardApi = createApi({
         { type: 'Board', id },
         { type: 'Board', id: 'LIST' }
       ]
+    }),
+
+    deleteBoard: build.mutation<DeleteBoardResType, string>({
+      query: (id) => ({ url: `${BOARD_API_URL}/${id}`, method: 'DELETE' }),
+      async onQueryStarted(_args, { queryFulfilled }) {
+        try {
+          await queryFulfilled
+        } catch (error) {
+          console.error(error)
+        }
+      },
+      invalidatesTags: [{ type: 'Board', id: 'LIST' }]
     })
   })
 })
@@ -106,7 +124,8 @@ export const {
   useLazyGetBoardsQuery,
   useUpdateBoardMutation,
   useLeaveBoardMutation,
-  useGetJoinedWorkspaceBoardsQuery
+  useGetJoinedWorkspaceBoardsQuery,
+  useDeleteBoardMutation
 } = boardApi
 
 const boardApiReducer = boardApi.reducer

--- a/src/schemas/board.schema.ts
+++ b/src/schemas/board.schema.ts
@@ -112,3 +112,9 @@ export const UpdateBoardBody = z.object({
 })
 
 export type UpdateBoardBodyType = z.TypeOf<typeof UpdateBoardBody>
+
+export const DeleteBoardRes = z.object({
+  message: z.string()
+})
+
+export type DeleteBoardResType = z.TypeOf<typeof DeleteBoardRes>


### PR DESCRIPTION
This pull request introduces the ability to permanently delete boards, including a user confirmation popover to prevent accidental deletions. The changes span UI, permissions, API integration, and schema updates.

**Major changes:**
- Added a `DeleteBoard` component and integrated it into board drawers and closed boards lists.
- Updated board permissions to include `BOARD__DELETE` and adjusted permission logic to restrict deletion to users with the correct role and only for closed boards.
- Implemented a confirmation popover for board deletion actions, providing clear warnings and requiring explicit user confirmation.
- Extended RTK Query board API with a `deleteBoard` mutation and corresponding Zod schema for the delete response.
- Updated UI in both workspace and board contexts to support board deletion, including real-time updates via Socket.IO events.
- Refactored affected components to pass and handle the new `onDeleteBoard` callback.
- Minor UI improvements for responsive layout in workspace home and board lists.

**Important notes:**
- Deleting a board is irreversible; all columns, cards, and actions are permanently removed.
- Only users with the `DeleteBoard` permission on closed boards can perform this action.
- Real-time updates ensure all clients reflect board deletions immediately.
- No undo is available for this operation.