### PR TITLE
Implement Workspace Deletion with Board Re-assignment and UI/Schema Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Trellone is a Kanban-style project management app inspired by Trello. This repos
 - 🧭 Workspaces, members/guests, invitations, access control
 - 🔐 Email/password auth, account verification, JWT, Google OAuth
 - ⚡ Real-time updates via Socket.IO
-- 📝 Markdown editor, 😀 reactions, 📎 attachments, ⏰ due dates, 📅 date pickers
+- 📝 Rich text editor, 😀 reactions, 📎 attachments, ⏰ due dates, 📅 date pickers
 - 🎨 Polished UI with MUI, light/dark modes, and toast notifications
 
 ### Tech Stack 🧰

--- a/src/hooks/use-categorize-workspaces.ts
+++ b/src/hooks/use-categorize-workspaces.ts
@@ -39,7 +39,8 @@ export const useCategorizeWorkspaces = (workspaces: WorkspaceResType['result'][]
           typeof guest === 'string' ? guest === profile._id : guest._id === profile._id
         )
 
-        if (isGuest) {
+        // Only show guest workspace if it has at least one active board
+        if (isGuest && activeBoards.length > 0) {
           guestWorkspaces.push({ ...workspace, boards: activeBoards })
         }
       }

--- a/src/pages/Boards/BoardDetails/BoardDetails.tsx
+++ b/src/pages/Boards/BoardDetails/BoardDetails.tsx
@@ -346,13 +346,15 @@ export default function BoardDetails() {
         {isClosed && <BoardClosedBanner />}
 
         <Box sx={{ display: 'flex' }}>
-          <WorkspaceDrawer
-            open={workspaceDrawerOpen}
-            onOpen={setWorkspaceDrawerOpen}
-            boardId={boardId}
-            workspace={activeBoard.workspace}
-            isBoardClosed={isClosed}
-          />
+          {activeBoard.workspace_id && (
+            <WorkspaceDrawer
+              open={workspaceDrawerOpen}
+              onOpen={setWorkspaceDrawerOpen}
+              boardId={boardId}
+              workspace={activeBoard.workspace}
+              isBoardClosed={isClosed}
+            />
+          )}
 
           <BoardBar
             workspaceDrawerOpen={workspaceDrawerOpen}
@@ -362,10 +364,11 @@ export default function BoardDetails() {
             board={activeBoard}
             isBoardMember={isMember}
             canManageBoard={canManageBoard}
+            hasWorkspace={!!activeBoard.workspace_id}
           />
 
           <Main
-            workspaceDrawerOpen={workspaceDrawerOpen}
+            workspaceDrawerOpen={activeBoard.workspace_id ? workspaceDrawerOpen : false}
             boardDrawerOpen={boardDrawerOpen}
             sx={{
               overflowX: 'auto',

--- a/src/pages/Boards/BoardDetails/components/BoardBar/BoardBar.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardBar/BoardBar.tsx
@@ -28,6 +28,7 @@ interface BoardBarProps {
   board: BoardResType['result']
   isBoardMember: boolean
   canManageBoard: boolean
+  hasWorkspace: boolean
 }
 
 const MENU_STYLES = {
@@ -52,7 +53,8 @@ export default function BoardBar({
   onBoardDrawerOpen,
   board,
   isBoardMember,
-  canManageBoard
+  canManageBoard,
+  hasWorkspace
 }: BoardBarProps) {
   const [editBoardTitleFormOpen, setEditBoardTitleFormOpen] = useState(false)
   const [boardTitle, setBoardTitle] = useState('')
@@ -114,7 +116,7 @@ export default function BoardBar({
         dispatch(updateActiveBoard(newActiveBoard))
         dispatch(
           workspaceApi.util.invalidateTags([
-            { type: 'Workspace', id: newActiveBoard.workspace_id },
+            { type: 'Workspace', id: newActiveBoard.workspace_id as string },
             { type: 'Workspace', id: 'LIST' }
           ])
         )
@@ -127,7 +129,7 @@ export default function BoardBar({
 
   const joinWorkspaceBoard = () => {
     joinWorkspaceBoardMutation({
-      workspace_id: board.workspace_id,
+      workspace_id: board.workspace_id as string,
       board_id: board._id
     }).then((res) => {
       if (!res.error) {
@@ -168,7 +170,7 @@ export default function BoardBar({
         zIndex: 999
       }}
       position='absolute'
-      workspaceDrawerOpen={workspaceDrawerOpen}
+      workspaceDrawerOpen={hasWorkspace && workspaceDrawerOpen}
       boardDrawerOpen={boardDrawerOpen}
     >
       <Toolbar
@@ -185,15 +187,17 @@ export default function BoardBar({
         variant='dense'
       >
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-          <IconButton
-            color='inherit'
-            aria-label='open workspace drawer'
-            onClick={() => onWorkspaceDrawerOpen(true)}
-            edge='start'
-            sx={{ ...(workspaceDrawerOpen && { display: 'none' }) }}
-          >
-            <MenuIcon />
-          </IconButton>
+          {hasWorkspace && (
+            <IconButton
+              color='inherit'
+              aria-label='open workspace drawer'
+              onClick={() => onWorkspaceDrawerOpen(true)}
+              edge='start'
+              sx={{ ...(workspaceDrawerOpen && { display: 'none' }) }}
+            >
+              <MenuIcon />
+            </IconButton>
+          )}
 
           <Tooltip title={board.description}>
             {editBoardTitleFormOpen ? (
@@ -233,7 +237,7 @@ export default function BoardBar({
           }}
         >
           {isBoardMember ? (
-            <InviteBoardMembers boardId={board._id} workspaceId={board.workspace_id} />
+            <InviteBoardMembers boardId={board._id} workspaceId={board.workspace_id as string} />
           ) : (
             <Tooltip title='Workspace members can join this board'>
               <Button size='small' color='secondary' variant='contained' onClick={joinWorkspaceBoard}>

--- a/src/pages/Boards/BoardDetails/components/BoardClosedBanner/BoardClosedBanner.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardClosedBanner/BoardClosedBanner.tsx
@@ -1,11 +1,28 @@
 import Box from '@mui/material/Box'
-import Typography from '@mui/material/Typography'
+import Button from '@mui/material/Button'
+import CloseIcon from '@mui/icons-material/Close'
+import IconButton from '@mui/material/IconButton'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
-import { useUpdateBoardMutation } from '~/queries/boards'
+import MenuItem from '@mui/material/MenuItem'
+import Popover from '@mui/material/Popover'
+import Select, { SelectChangeEvent } from '@mui/material/Select'
+import Typography from '@mui/material/Typography'
+import { useMemo, useState } from 'react'
+import { useCategorizeWorkspaces } from '~/hooks/use-categorize-workspaces'
 import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
+import { useUpdateBoardMutation } from '~/queries/boards'
+import { useGetWorkspacesQuery } from '~/queries/workspaces'
 import { updateActiveBoard } from '~/store/slices/board.slice'
 
 export default function BoardClosedBanner() {
+  const [anchorSelectWorkspacePopoverElement, setAnchorSelectWorkspacePopoverElement] = useState<HTMLElement | null>(
+    null
+  )
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string>('')
+
+  const isSelectWorkspacePopoverOpen = Boolean(anchorSelectWorkspacePopoverElement)
+  const selectWorkspacePopoverId = isSelectWorkspacePopoverOpen ? 'select-workspace-popover' : undefined
+
   const [updateBoardMutation] = useUpdateBoardMutation()
 
   const dispatch = useAppDispatch()
@@ -13,89 +30,214 @@ export default function BoardClosedBanner() {
   const { activeBoard } = useAppSelector((state) => state.board)
   const { socket } = useAppSelector((state) => state.app)
 
-  const reopenBoard = () => {
-    updateBoardMutation({ id: activeBoard?._id as string, body: { _destroy: false } }).then((res) => {
+  const { data: workspacesData } = useGetWorkspacesQuery({ page: 1, limit: 100 })
+
+  const workspacesList = useMemo(() => workspacesData?.result.workspaces || [], [workspacesData])
+
+  const { memberWorkspaces } = useCategorizeWorkspaces(workspacesList)
+
+  const handleSelectWorkspacePopoverClose = () => {
+    setAnchorSelectWorkspacePopoverElement(null)
+    setSelectedWorkspaceId('')
+  }
+
+  const handleWorkspaceChange = (event: SelectChangeEvent<string>) => {
+    setSelectedWorkspaceId(event.target.value)
+  }
+
+  const handleReopenClick = (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+    // If board has no workspace (workspace was deleted), show workspace selector
+    if (activeBoard?.workspace_id === null) {
+      setAnchorSelectWorkspacePopoverElement(event.currentTarget as HTMLElement)
+    } else {
+      // Otherwise, reopen normally
+      reopenBoard()
+    }
+  }
+
+  const reopenBoard = (newWorkspaceId?: string) => {
+    const body: { _destroy: boolean; workspace_id?: string } = { _destroy: false }
+
+    // If newWorkspaceId is provided (for boards with deleted workspace), update workspace_id
+    if (newWorkspaceId !== undefined) {
+      body.workspace_id = newWorkspaceId
+    }
+
+    updateBoardMutation({ id: activeBoard?._id as string, body }).then((res) => {
       if (!res.error) {
         const newActiveBoard = { ...activeBoard! }
         newActiveBoard._destroy = false
+
+        if (newWorkspaceId !== undefined) {
+          newActiveBoard.workspace_id = newWorkspaceId
+
+          const newWorkspace = workspacesList.find((workspace) => workspace._id === newWorkspaceId)
+
+          if (newWorkspace) {
+            newActiveBoard.workspace = {
+              _id: newWorkspace._id,
+              title: newWorkspace.title,
+              logo: newWorkspace.logo,
+              boards: newWorkspace.boards || [],
+              members: newWorkspace.members || [],
+              guests: Array.isArray(newWorkspace.guests)
+                ? newWorkspace.guests.map((guest) => (typeof guest === 'string' ? guest : guest._id))
+                : []
+            }
+          }
+        }
 
         dispatch(updateActiveBoard(newActiveBoard))
 
         socket?.emit('CLIENT_USER_UPDATED_BOARD', newActiveBoard)
 
-        // NOTE: Although it’s possible to refetch the get board details API so that members in that board can notice the realtime update
+        const targetWorkspaceId = newWorkspaceId !== undefined ? newWorkspaceId : activeBoard?.workspace_id
+
+        // NOTE: Although it's possible to refetch the get board details API so that members in that board can notice the realtime update
         // But I will let users reload the board details page when they reopen that board
-        socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', newActiveBoard.workspace_id)
+        if (targetWorkspaceId) {
+          socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', targetWorkspaceId)
+        }
+
+        handleSelectWorkspacePopoverClose()
       }
     })
   }
 
+  const reopenBoardWithWorkspace = () => {
+    if (selectedWorkspaceId) {
+      reopenBoard(selectedWorkspaceId)
+    }
+  }
+
   return (
-    <Box
-      role='status'
-      aria-live='polite'
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'flex-start',
-        width: '100%',
-        minWidth: 0,
-        gap: 1.5,
-        px: 2,
-        py: 1.25,
-        bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primary.dark' : 'primary.dark'),
-        color: 'common.white',
-        borderTop: (theme) => `1px solid ${theme.palette.divider}`,
-        borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
-        position: 'relative',
-        zIndex: 1,
-        height: '48px',
-        overflowX: 'auto',
-        overflowY: 'hidden',
-        flexWrap: 'nowrap',
-        WebkitOverflowScrolling: 'touch'
-      }}
-    >
+    <>
       <Box
-        component='span'
+        role='status'
+        aria-live='polite'
         sx={{
-          display: 'inline-flex',
+          display: 'flex',
           alignItems: 'center',
+          justifyContent: 'flex-start',
+          width: '100%',
+          minWidth: 0,
           gap: 1.5,
-          whiteSpace: 'nowrap',
-          width: 'max-content',
-          flexShrink: 0,
-          mx: 'auto'
+          px: 2,
+          py: 1.25,
+          bgcolor: (theme) => (theme.palette.mode === 'dark' ? 'primary.dark' : 'primary.dark'),
+          color: 'common.white',
+          borderTop: (theme) => `1px solid ${theme.palette.divider}`,
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+          position: 'relative',
+          zIndex: 1,
+          height: '48px',
+          overflowX: 'auto',
+          overflowY: 'hidden',
+          flexWrap: 'nowrap',
+          WebkitOverflowScrolling: 'touch'
         }}
       >
-        <InfoOutlinedIcon sx={{ fontSize: 20, opacity: 0.9, flexShrink: 0 }} />
-        <Typography
+        <Box
           component='span'
-          variant='body2'
           sx={{
-            opacity: 0.95,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 1.5,
             whiteSpace: 'nowrap',
-            flexShrink: 0
+            width: 'max-content',
+            flexShrink: 0,
+            mx: 'auto'
           }}
         >
-          This board is closed. Reopen the board to make changes.{' '}
+          <InfoOutlinedIcon sx={{ fontSize: 20, opacity: 0.9, flexShrink: 0 }} />
           <Typography
             component='span'
             variant='body2'
             sx={{
               opacity: 0.95,
-              textDecoration: 'underline',
-              cursor: 'pointer',
-              fontSize: 'inherit',
               whiteSpace: 'nowrap',
               flexShrink: 0
             }}
-            onClick={reopenBoard}
           >
-            Reopen board
+            This board is closed. Reopen the board to make changes.{' '}
+            <Typography
+              component='span'
+              variant='body2'
+              sx={{
+                opacity: 0.95,
+                textDecoration: 'underline',
+                cursor: 'pointer',
+                fontSize: 'inherit',
+                whiteSpace: 'nowrap',
+                flexShrink: 0
+              }}
+              onClick={handleReopenClick}
+            >
+              Reopen board
+            </Typography>
           </Typography>
-        </Typography>
+        </Box>
       </Box>
-    </Box>
+
+      <Popover
+        id={selectWorkspacePopoverId}
+        open={isSelectWorkspacePopoverOpen}
+        anchorEl={anchorSelectWorkspacePopoverElement}
+        onClose={handleSelectWorkspacePopoverClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        slotProps={{
+          paper: { sx: { width: 320, borderRadius: 2 } }
+        }}
+      >
+        <Box sx={{ p: 2 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              mb: 2,
+              position: 'relative'
+            }}
+          >
+            <Typography variant='subtitle1' sx={{ fontWeight: 'medium' }}>
+              Select a Workspace
+            </Typography>
+            <IconButton
+              size='small'
+              onClick={handleSelectWorkspacePopoverClose}
+              sx={{ position: 'absolute', right: 0 }}
+            >
+              <CloseIcon fontSize='small' />
+            </IconButton>
+          </Box>
+
+          <Typography variant='body2' sx={{ mb: 2, color: 'text.secondary' }}>
+            Your Workspaces
+          </Typography>
+
+          <Select
+            size='small'
+            fullWidth
+            value={selectedWorkspaceId}
+            onChange={handleWorkspaceChange}
+            displayEmpty
+            sx={{ mb: 2 }}
+          >
+            <MenuItem value='' disabled>
+              Choose...
+            </MenuItem>
+            {memberWorkspaces.map((workspace) => (
+              <MenuItem key={workspace._id} value={workspace._id}>
+                {workspace.title}
+              </MenuItem>
+            ))}
+          </Select>
+
+          <Button variant='contained' fullWidth disabled={!selectedWorkspaceId} onClick={reopenBoardWithWorkspace}>
+            Reopen board
+          </Button>
+        </Box>
+      </Popover>
+    </>
   )
 }

--- a/src/pages/Boards/BoardDetails/components/BoardDrawer/CloseBoard/CloseBoard.tsx
+++ b/src/pages/Boards/BoardDetails/components/BoardDrawer/CloseBoard/CloseBoard.tsx
@@ -15,6 +15,7 @@ import path from '~/constants/path'
 import { useUpdateBoardMutation } from '~/queries/boards'
 import { useAppDispatch, useAppSelector } from '~/lib/redux/hooks'
 import { updateActiveBoard } from '~/store/slices/board.slice'
+import { workspaceApi } from '~/queries/workspaces'
 
 export default function CloseBoard() {
   const [anchorCloseBoardPopoverElement, setAnchorCloseBoardPopoverElement] = useState<HTMLElement | null>(null)
@@ -52,6 +53,7 @@ export default function CloseBoard() {
         newActiveBoard._destroy = true
 
         dispatch(updateActiveBoard(newActiveBoard))
+        dispatch(workspaceApi.util.invalidateTags([{ type: 'Workspace', id: 'LIST' }]))
 
         socket?.emit('CLIENT_USER_UPDATED_BOARD', newActiveBoard)
         socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', newActiveBoard.workspace_id, newActiveBoard._id)

--- a/src/pages/Workspaces/pages/BoardsList/BoardsList.tsx
+++ b/src/pages/Workspaces/pages/BoardsList/BoardsList.tsx
@@ -115,11 +115,6 @@ export default function BoardsList() {
 
   const allWorkspaces = useMemo(() => [...memberWorkspaces, ...guestWorkspaces], [memberWorkspaces, guestWorkspaces])
 
-  const hasClosedBoards = useMemo(
-    () => workspaces.some((workspace) => workspace.boards.some((board) => board._destroy)),
-    [workspaces]
-  )
-
   // Realtime: listen to workspace updates and refresh list
   useEffect(() => {
     if (!socket) return
@@ -296,7 +291,7 @@ export default function BoardsList() {
         )}
       </Box>
 
-      {hasClosedBoards && <ClosedBoards workspaces={allWorkspaces} />}
+      <ClosedBoards workspaces={allWorkspaces} />
     </Box>
   )
 }

--- a/src/pages/Workspaces/pages/WorkspaceSettings/WorkspaceSettings.tsx
+++ b/src/pages/Workspaces/pages/WorkspaceSettings/WorkspaceSettings.tsx
@@ -2,7 +2,6 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined'
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined'
 import PublicOutlinedIcon from '@mui/icons-material/PublicOutlined'
 import Box from '@mui/material/Box'
-import Button from '@mui/material/Button'
 import Divider from '@mui/material/Divider'
 import IconButton from '@mui/material/IconButton'
 import Skeleton from '@mui/material/Skeleton'
@@ -18,6 +17,7 @@ import { WorkspaceType } from '~/constants/type'
 import { useWorkspacePermission } from '~/hooks/use-permissions'
 import WorkspaceLogo from '~/pages/Workspaces/components/WorkspaceLogo'
 import EditWorkspaceDialog from '~/pages/Workspaces/pages/WorkspaceHome/components/EditWorkspaceDialog'
+import DeleteWorkspace from '~/pages/Workspaces/pages/WorkspaceSettings/components/DeleteWorkspace'
 import WorkspaceVisibility from '~/pages/Workspaces/pages/WorkspaceSettings/components/WorkspaceVisibility'
 import { useGetWorkspaceQuery } from '~/queries/workspaces'
 import { WorkspaceVisibilityType } from '~/schemas/workspace.schema'
@@ -30,7 +30,7 @@ export default function WorkspaceSettings() {
   const { data: workspaceData, isLoading, isError } = useGetWorkspaceQuery(workspaceId!)
   const workspace = workspaceData?.result
 
-  const { hasPermission } = useWorkspacePermission(workspace)
+  const { hasPermission, canDeleteWorkspace } = useWorkspacePermission(workspace)
 
   if (isError) {
     return <Navigate to={path.boardsList} />
@@ -176,9 +176,12 @@ export default function WorkspaceSettings() {
       <Divider sx={{ my: 3 }} />
 
       <Box sx={{ display: 'flex', justifyContent: { xs: 'stretch', sm: 'flex-start' } }}>
-        <Button variant='contained' color='error' size='medium' sx={{ px: 2.5, fontWeight: 600 }} disabled>
-          Delete this Workspace?
-        </Button>
+        <DeleteWorkspace
+          workspaceId={workspaceId as string}
+          workspaceTitle={workspace?.title as string}
+          affectedBoardIds={workspace?.boards.map((board) => board._id) || []}
+          canDeleteWorkspace={canDeleteWorkspace}
+        />
       </Box>
 
       {workspace && (

--- a/src/pages/Workspaces/pages/WorkspaceSettings/components/DeleteWorkspace/DeleteWorkspace.tsx
+++ b/src/pages/Workspaces/pages/WorkspaceSettings/components/DeleteWorkspace/DeleteWorkspace.tsx
@@ -1,0 +1,215 @@
+import CloseIcon from '@mui/icons-material/Close'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import IconButton from '@mui/material/IconButton'
+import Popover from '@mui/material/Popover'
+import TextField from '@mui/material/TextField'
+import Typography from '@mui/material/Typography'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import path from '~/constants/path'
+import { useAppSelector } from '~/lib/redux/hooks'
+import { useDeleteWorkspaceMutation } from '~/queries/workspaces'
+
+interface DeleteWorkspaceProps {
+  workspaceId: string
+  workspaceTitle: string
+  affectedBoardIds: string[]
+  canDeleteWorkspace: boolean
+}
+
+export default function DeleteWorkspace({
+  workspaceId,
+  workspaceTitle,
+  affectedBoardIds,
+  canDeleteWorkspace
+}: DeleteWorkspaceProps) {
+  const navigate = useNavigate()
+
+  const [anchorDeleteWorkspacePopoverElement, setAnchorDeleteWorkspacePopoverElement] = useState<HTMLElement | null>(
+    null
+  )
+  const [confirmWorkspaceName, setConfirmWorkspaceName] = useState('')
+
+  const isDeleteWorkspacePopoverOpen = Boolean(anchorDeleteWorkspacePopoverElement)
+
+  const deleteWorkspacePopoverId = isDeleteWorkspacePopoverOpen ? 'delete-workspace-popover' : undefined
+
+  const toggleDeleteWorkspacePopover = (event: React.MouseEvent<HTMLButtonElement>) => {
+    if (isDeleteWorkspacePopoverOpen) {
+      setAnchorDeleteWorkspacePopoverElement(null)
+      setConfirmWorkspaceName('')
+    } else {
+      setAnchorDeleteWorkspacePopoverElement(event.currentTarget)
+    }
+  }
+
+  const handleDeleteWorkspacePopoverClose = () => {
+    setAnchorDeleteWorkspacePopoverElement(null)
+    setConfirmWorkspaceName('')
+  }
+
+  const isDeleteButtonDisabled = confirmWorkspaceName !== workspaceTitle
+
+  const { socket } = useAppSelector((state) => state.app)
+
+  const [deleteWorkspaceMutation] = useDeleteWorkspaceMutation()
+
+  const deleteWorkspace = () => {
+    if (!isDeleteButtonDisabled) {
+      deleteWorkspaceMutation(workspaceId).then((res) => {
+        if (!res.error) {
+          for (const boardId of affectedBoardIds) {
+            socket?.emit('CLIENT_USER_UPDATED_WORKSPACE', workspaceId, boardId)
+          }
+
+          navigate(path.boardsList)
+
+          handleDeleteWorkspacePopoverClose()
+        }
+      })
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant='contained'
+        color='error'
+        size='medium'
+        sx={{ px: 2.5, fontWeight: 600 }}
+        onClick={toggleDeleteWorkspacePopover}
+        disabled={!canDeleteWorkspace}
+      >
+        Delete this Workspace?
+      </Button>
+
+      <Popover
+        id={deleteWorkspacePopoverId}
+        open={isDeleteWorkspacePopoverOpen}
+        anchorEl={anchorDeleteWorkspacePopoverElement}
+        onClose={handleDeleteWorkspacePopoverClose}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        slotProps={{
+          paper: {
+            sx: {
+              width: 350,
+              borderRadius: 2,
+              bgcolor: 'background.paper'
+            }
+          }
+        }}
+      >
+        <Box sx={{ p: 2.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 2 }}>
+            <Typography variant='h6' sx={{ fontWeight: 600, fontSize: '1.125rem' }}>
+              Delete Workspace?
+            </Typography>
+            <IconButton
+              size='small'
+              onClick={handleDeleteWorkspacePopoverClose}
+              sx={{
+                color: 'text.secondary',
+                '&:hover': { bgcolor: 'action.hover' }
+              }}
+            >
+              <CloseIcon fontSize='small' />
+            </IconButton>
+          </Box>
+
+          <Typography variant='body2' sx={{ mb: 2.5, color: 'text.primary', lineHeight: 1.6 }}>
+            Enter the Workspace name{' '}
+            <Typography
+              component='span'
+              sx={{
+                fontWeight: 700,
+                color: 'text.primary'
+              }}
+            >
+              "{workspaceTitle}"
+            </Typography>{' '}
+            to delete
+          </Typography>
+
+          <Box sx={{ mb: 2.5 }}>
+            <Typography variant='body2' sx={{ fontWeight: 600, mb: 1.5, color: 'text.primary' }}>
+              Things to know:
+            </Typography>
+
+            <Box component='ul' sx={{ m: 0, pl: 2.5, '& li': { mb: 1, color: 'text.secondary' } }}>
+              <li>
+                <Typography variant='body2' sx={{ lineHeight: 1.6 }}>
+                  This is permanent and can't be undone.
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' sx={{ lineHeight: 1.6 }}>
+                  All boards in this Workspace will be closed.
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' sx={{ lineHeight: 1.6 }}>
+                  Board admins can reopen boards.
+                </Typography>
+              </li>
+              <li>
+                <Typography variant='body2' sx={{ lineHeight: 1.6, mb: 0 }}>
+                  Board members will not be able to interact with closed boards.
+                </Typography>
+              </li>
+            </Box>
+          </Box>
+
+          <Box sx={{ mb: 2.5 }}>
+            <Typography
+              variant='body2'
+              sx={{
+                mb: 1,
+                fontWeight: 500,
+                color: 'text.primary',
+                fontSize: '0.8125rem'
+              }}
+            >
+              Enter the Workspace name to delete
+            </Typography>
+            <TextField
+              fullWidth
+              size='small'
+              value={confirmWorkspaceName}
+              onChange={(e) => setConfirmWorkspaceName(e.target.value)}
+              placeholder={workspaceTitle}
+              autoComplete='off'
+              sx={{
+                '& .MuiOutlinedInput-root': {
+                  bgcolor: 'background.paper',
+                  '&:hover fieldset': {
+                    borderColor: 'divider'
+                  },
+                  '&.Mui-focused fieldset': {
+                    borderColor: 'primary.main'
+                  }
+                }
+              }}
+            />
+          </Box>
+
+          <Button
+            variant='contained'
+            color='error'
+            fullWidth
+            onClick={deleteWorkspace}
+            disabled={isDeleteButtonDisabled}
+            sx={{
+              fontWeight: 600,
+              py: 1,
+              textTransform: 'none',
+              fontSize: '0.9375rem'
+            }}
+          >
+            Delete Workspace
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  )
+}

--- a/src/pages/Workspaces/pages/WorkspaceSettings/components/DeleteWorkspace/index.ts
+++ b/src/pages/Workspaces/pages/WorkspaceSettings/components/DeleteWorkspace/index.ts
@@ -1,0 +1,3 @@
+import DeleteWorkspace from '~/pages/Workspaces/pages/WorkspaceSettings/components/DeleteWorkspace/DeleteWorkspace'
+
+export default DeleteWorkspace

--- a/src/queries/boards.ts
+++ b/src/queries/boards.ts
@@ -30,7 +30,7 @@ export const boardApi = createApi({
 
           dispatch(
             workspaceApi.util.invalidateTags([
-              { type: 'Workspace', id: board?.workspace_id },
+              { type: 'Workspace', id: board?.workspace_id as string },
               { type: 'Workspace', id: 'LIST' }
             ])
           )

--- a/src/queries/workspaces.ts
+++ b/src/queries/workspaces.ts
@@ -5,6 +5,7 @@ import { boardApi } from '~/queries/boards'
 import { BoardResType } from '~/schemas/board.schema'
 import {
   CreateWorkspaceBodyType,
+  DeleteWorkspaceResType,
   EditWorkspaceMemberRoleBodyType,
   RemoveGuestFromBoardBodyType,
   RemoveGuestFromWorkspaceResType,
@@ -154,6 +155,18 @@ export const workspaceApi = createApi({
         { type: 'Workspace', id: workspace_id },
         { type: 'Workspace', id: 'LIST' }
       ]
+    }),
+
+    deleteWorkspace: build.mutation<DeleteWorkspaceResType, string>({
+      query: (id) => ({ url: `${WORKSPACE_API_URL}/${id}`, method: 'DELETE' }),
+      async onQueryStarted(_args, { queryFulfilled }) {
+        try {
+          await queryFulfilled
+        } catch (error) {
+          console.error(error)
+        }
+      },
+      invalidatesTags: [{ type: 'Workspace', id: 'LIST' }]
     })
   })
 })
@@ -170,7 +183,8 @@ export const {
   useAddGuestToWorkspaceMutation,
   useRemoveGuestFromWorkspaceMutation,
   useRemoveGuestFromBoardMutation,
-  useJoinWorkspaceBoardMutation
+  useJoinWorkspaceBoardMutation,
+  useDeleteWorkspaceMutation
 } = workspaceApi
 
 const workspaceApiReducer = workspaceApi.reducer

--- a/src/schemas/board.schema.ts
+++ b/src/schemas/board.schema.ts
@@ -22,7 +22,7 @@ export const BoardSchema = z.object({
   description: z.string().optional(),
   type: z.enum(BoardTypeValues),
   cover_photo: z.string().optional(),
-  workspace_id: z.string(),
+  workspace_id: z.string().nullable(),
   column_order_ids: z.array(z.string()),
   members: z.array(BoardMemberSchema),
   columns: z.array(ColumnSchema).optional(),
@@ -108,6 +108,7 @@ export const UpdateBoardBody = z.object({
     .optional(),
   column_order_ids: z.array(z.string()).optional(),
   cover_photo: z.string().url().optional(),
+  workspace_id: z.string().optional(),
   _destroy: z.boolean().optional()
 })
 

--- a/src/schemas/workspace.schema.ts
+++ b/src/schemas/workspace.schema.ts
@@ -122,3 +122,9 @@ export const RemoveGuestFromWorkspaceRes = z.object({
 })
 
 export type RemoveGuestFromWorkspaceResType = z.TypeOf<typeof RemoveGuestFromWorkspaceRes>
+
+export const DeleteWorkspaceRes = z.object({
+  message: z.string()
+})
+
+export type DeleteWorkspaceResType = z.TypeOf<typeof DeleteWorkspaceRes>


### PR DESCRIPTION
This PR introduces the ability to delete workspaces and re-assign or close associated boards, along with several related improvements and refactors:

- **Workspace Deletion Feature**
  - Added a new `DeleteWorkspace` component with confirmation popover and safety checks.
  - Only users with the correct permission can delete a workspace.
  - Deleting a workspace closes all its boards; board admins can later reopen them.
  - Real-time socket events are emitted to update affected boards for all users.

- **Board Re-assignment and Closed Board Handling**
  - Enhanced closed board management: boards from deleted workspaces are now handled as closed and can be reassigned to other workspaces.
  - Improved UI for reopening closed boards, including workspace selection and validation.
  - Updated board and workspace schemas to support nullable `workspace_id` and board re-assignment.

- **API and State Management**
  - Added `deleteWorkspace` mutation to the RTK Query workspace API slice.
  - Updated cache invalidation logic for workspace and board mutations.
  - Extended Zod schemas for workspace and board deletion responses.

- **UI/UX Improvements**
  - Improved guest workspace visibility logic (only show if there are active boards).
  - Refined BoardDetails and BoardBar to handle boards without a workspace.
  - Updated WorkspaceSettings to integrate the new deletion flow.
  - Enhanced closed boards list and row components for better clarity and actions.

- **Documentation**
  - Minor update to the README to clarify the use of a rich text editor.

**Important Notes:**
- This is a destructive operation: deleting a workspace is permanent and cannot be undone.
- All boards in a deleted workspace are closed; only board admins can reopen them.
- Board members lose access to closed boards until they are reopened and reassigned.
- Manual QA is recommended for workspace deletion, board re-assignment, and closed board flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 92d5658ef672261a3a437497886764dcefec6c0a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->